### PR TITLE
Add clear param to GET messages request

### DIFF
--- a/lib/lita/handlers/irkit.rb
+++ b/lib/lita/handlers/irkit.rb
@@ -20,6 +20,7 @@ module Lita
 
       def ir_register(response)
         cmd     = response.matches[0][0]
+        response.reply "waiting for ir data..."
         ir_data = irkit_api.get('messages', clientkey: config.clientkey, clear: 1).body
         return response.reply "ir data not found" if ir_data.length == 0
 

--- a/lib/lita/handlers/irkit.rb
+++ b/lib/lita/handlers/irkit.rb
@@ -20,7 +20,7 @@ module Lita
 
       def ir_register(response)
         cmd     = response.matches[0][0]
-        ir_data = irkit_api.get('messages', clientkey: config.clientkey).body
+        ir_data = irkit_api.get('messages', clientkey: config.clientkey, clear: 1).body
         return response.reply "ir data not found" if ir_data.length == 0
 
         messages_redis[cmd] = JSON.parse(ir_data)['message'].to_json


### PR DESCRIPTION
see also: http://getirkit.com/#toc_13

> GET /1/messages
> 最も新しい受信した赤外線信号を返します。 このリクエストは、ロングポーリングなリクエストです。 clear を指定すると、過去にIRKitデバイスがサーバに送信しサーバで保存している赤外線信号を消去し、 新しい赤外線信号がIRKitデバイスから届いたらただちにレスポンスを返します。 規定値でタイムアウトすると空のレスポンスを返します。
> 
> 赤外線信号を学習するシーンでは、最初に clear=1 をつけてリクエストをした後、リクエストがタイムアウトしたら clear パラメータを付与せずに再度リクエストするとよいでしょう。
